### PR TITLE
Fix: Ensure dots in divide icon are visible

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,13 @@ enum Operation {
 const PlusIcon = () => <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round"><path d="M12 5v14M5 12h14"></path></svg>;
 const MinusIcon = () => <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14"></path></svg>;
 const MultiplyIcon = () => <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round"><path d="M18 6L6 18M6 6l12 12"></path></svg>;
-const DivideIcon = () => <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round"><path d="M4.5 19.5l15-15"></path></svg>;
+const DivideIcon = () => (
+  <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M5 12h14"></path>
+    <circle cx="12" cy="7" r="1" fill="currentColor"></circle>
+    <circle cx="12" cy="17" r="1" fill="currentColor"></circle>
+  </svg>
+);
 
 export default function Home() {
   const [displayValue, setDisplayValue] = useState<string>("0");


### PR DESCRIPTION
Corrected the SVG for the division operator button to use a horizontal line with <circle> elements for the dots