### PR TITLE
Fix type error for Metal theme

### DIFF
--- a/src/app/contexts/ThemeContext.tsx
+++ b/src/app/contexts/ThemeContext.tsx
@@ -2,11 +2,12 @@
 
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 
-type Theme = 'default' | 'classic' | 'typewriter'; // Add more themes as needed
+type Theme = 'default' | 'classic' | 'typewriter' | 'metal'; // Add more themes as needed
 const THEME_FILES: Record<Theme, string | null> = {
   default: null, // No specific file for default, uses globals.css base
   classic: '/themes/classic.css',
   typewriter: '/themes/typewriter.css',
+  metal: '/themes/metal.css',
 };
 
 interface ThemeContextType {


### PR DESCRIPTION
## Summary
- support `metal` theme in ThemeContext

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684bf497fb28832cbe85abde0f170ca5