### PR TITLE
Add neon theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,14 @@
 ## Calculator
 
 Toy React Calculator for experimenting with CI/CD, AI agents, etc.
+
+### Themes
+
+The application supports multiple visual themes. Use the theme switcher at the
+top right of the app to try them. Available themes are:
+
+- **Default** – basic styling provided by `globals.css`.
+- **Classic** – retro calculator colors.
+- **Typewriter** – round keys with typewriter vibes.
+- **Metal** – shiny metallic gradients.
+- **Neon** – a fun, animated palette of bright neon colors.

--- a/public/themes/neon.css
+++ b/public/themes/neon.css
@@ -1,0 +1,62 @@
+:root {
+  --background: #000000;
+  --foreground: #ffffff;
+  --font-body: 'Comic Sans MS', cursive, sans-serif;
+  --font-button: 'Comic Sans MS', cursive, sans-serif;
+
+  --neon-color-1: #ff00ff;
+  --neon-color-2: #00ffff;
+  --neon-color-3: #39ff14;
+  --neon-color-4: #ffea00;
+  --neon-color-5: #ff6600;
+}
+
+@keyframes neon-cycle-1 {
+  0% { background-color: var(--neon-color-1); }
+  20% { background-color: var(--neon-color-2); }
+  40% { background-color: var(--neon-color-3); }
+  60% { background-color: var(--neon-color-4); }
+  80% { background-color: var(--neon-color-5); }
+  100% { background-color: var(--neon-color-1); }
+}
+
+@keyframes neon-cycle-2 {
+  0% { background-color: var(--neon-color-3); }
+  20% { background-color: var(--neon-color-4); }
+  40% { background-color: var(--neon-color-5); }
+  60% { background-color: var(--neon-color-1); }
+  80% { background-color: var(--neon-color-2); }
+  100% { background-color: var(--neon-color-3); }
+}
+
+.btn-base {
+  border: none;
+  color: var(--foreground);
+  box-shadow: 0 0 8px currentColor, 0 0 16px currentColor;
+  animation-duration: 6s;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+.number-button {
+  animation-name: neon-cycle-1;
+}
+
+.operation-button {
+  animation-name: neon-cycle-2;
+}
+
+.special-button {
+  animation-name: neon-cycle-1;
+  animation-duration: 4s;
+  filter: brightness(1.3);
+}
+
+.btn-hover:hover {
+  filter: brightness(1.6) drop-shadow(0 0 10px currentColor);
+}
+
+.buttons-grid:has(.btn-base:hover) .btn-base:not(:hover) {
+  filter: brightness(0.8);
+  animation-direction: reverse;
+}

--- a/src/app/components/ThemeSwitcher.tsx
+++ b/src/app/components/ThemeSwitcher.tsx
@@ -34,6 +34,9 @@ const ThemeSwitcher: React.FC = () => {
         <button onClick={() => setTheme('metal')} disabled={theme === 'metal'} style={buttonStyle(theme === 'metal')}>
           Metal
         </button>
+        <button onClick={() => setTheme('neon')} disabled={theme === 'neon'} style={buttonStyle(theme === 'neon')}>
+          Neon
+        </button>
       </div>
     </div>
   );

--- a/src/app/contexts/ThemeContext.tsx
+++ b/src/app/contexts/ThemeContext.tsx
@@ -2,12 +2,13 @@
 
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 
-type Theme = 'default' | 'classic' | 'typewriter' | 'metal'; // Add more themes as needed
+type Theme = 'default' | 'classic' | 'typewriter' | 'metal' | 'neon'; // Add more themes as needed
 const THEME_FILES: Record<Theme, string | null> = {
   default: null, // No specific file for default, uses globals.css base
   classic: '/themes/classic.css',
   typewriter: '/themes/typewriter.css',
   metal: '/themes/metal.css',
+  neon: '/themes/neon.css',
 };
 
 interface ThemeContextType {


### PR DESCRIPTION
## Summary
- add bright, animated Neon theme and theme option
- document available themes

## Testing
- `npm test` *(fails: no test script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1249e89c832cb490f09de8a63668