### PR TITLE
Configure vitest test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
 		"deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
 		"preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
 		"versioned-deploy": "opennextjs-cloudflare build && wrangler versions upload",
-		"cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts"
-	},
+                "cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts",
+                "test": "vitest"
+        },
 	"dependencies": {
 		"@opennextjs/cloudflare": "^1.2.1",
 		"next": "15.3.3",
@@ -28,6 +29,9 @@
 		"eslint-config-next": "15.3.3",
 		"tailwindcss": "^4",
 		"typescript": "^5",
-		"wrangler": "^4.19.1"
-	}
+                "wrangler": "^4.19.1",
+                "vitest": "^1.5.0",
+                "@testing-library/react": "^14.2.1",
+                "@testing-library/jest-dom": "^6.4.1"
+        }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,6 @@
+import { vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+
+// Provide `jest` global for tests written for Jest
+// Vitest's `vi` is API compatible with `jest`
+(globalThis as any).jest = vi;


### PR DESCRIPTION
## Summary
- add Vitest config files
- install Vitest and Testing Library
- add npm `test` script

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c142b87e4832c8765167f87b7b859