### PR TITLE
Enable algebraic mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,4 @@
 
 - Consult `TODO.md` in the repository root to understand the current roadmap and pending tasks.
 - When a task in `TODO.md` is finished, move it to the **Recently completed work** section of that file to keep the list up to date.
+- Keep `README.md` updated with new features so users know how to use them.

--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ top right of the app to try them. Available themes are:
 - **Metal** – shiny metallic gradients.
 - **Neon** – a fun, animated palette of bright neon colors.
 
+### Modes
+
+Use the mode toggle at the top right to switch between **classic** and **algebraic** modes. Algebraic mode shows extra parentheses buttons and lets you type expressions like `1-(2×3)` directly in the display. Evaluation of these algebraic expressions isn't implemented yet, so `=` currently does nothing in this mode.
+

--- a/TODO.md
+++ b/TODO.md
@@ -23,16 +23,12 @@ Keeping the symbolic logic in `src/lib/symbolic` keeps the React UI focused only
 
 ## Step-by-step Path
 
-1. **Add algebraic/classic mode toggle**
-   - Place a toggle next to the existing theme switcher.
-   - When set to **Algebraic** the keypad should include `(` and `)` keys.
-   - **Classic** remains the current four‑function behaviour.
 2. **Add `ExpressionInput` component**
    - Text field above the keypad for typing complete expressions.
    - When `=` or `Enter` is pressed in algebraic mode, evaluate the expression.
    - User-visible change: typed expressions like `2*(3+4)` are handled.
 3. **Build the parser** (`parser.ts`)
-   - Tokenise basic operators (+, -, ∗, /) and parentheses.
+   - Tokenise basic operators (+, -, ×, ÷) and parentheses.
    - Produce an AST structure used throughout the symbolic engine.
    - Include unit tests to validate parsing.
 4. **Numeric evaluation using the AST** (`evaluate.ts`)
@@ -59,4 +55,4 @@ Each stage introduces new functionality visible to the user while keeping the im
 
 ## Recently completed work
 
-(none yet)
+- Added algebraic/classic mode toggle with parentheses keys

--- a/src/app/components/ModeToggle.tsx
+++ b/src/app/components/ModeToggle.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React from 'react';
+import { useMode } from '../contexts/ModeContext';
+
+const ModeToggle: React.FC = () => {
+  const { mode, setMode } = useMode();
+
+  return (
+    <div
+      style={{
+        padding: '10px',
+        background: 'rgba(255,255,255,0.8)',
+        border: '1px solid #ccc',
+        zIndex: 1000,
+        fontFamily: 'Arial, Helvetica, sans-serif',
+        fontSize: '14px',
+      }}
+    >
+      <p style={{ marginBottom: '8px' }}>
+        Mode: <strong>{mode}</strong>
+      </p>
+      <div style={{ display: 'flex', gap: '8px' }}>
+        <button
+          onClick={() => setMode('classic')}
+          disabled={mode === 'classic'}
+          style={buttonStyle(mode === 'classic')}
+        >
+          Classic
+        </button>
+        <button
+          onClick={() => setMode('algebraic')}
+          disabled={mode === 'algebraic'}
+          style={buttonStyle(mode === 'algebraic')}
+        >
+          Algebraic
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const buttonStyle = (isActive: boolean) => ({
+  padding: '8px 12px',
+  border: '1px solid #007bff',
+  backgroundColor: isActive ? '#007bff' : '#ffffff',
+  color: isActive ? '#ffffff' : '#007bff',
+  cursor: 'pointer',
+  borderRadius: '4px',
+  opacity: isActive ? 0.7 : 1,
+  fontFamily: 'Arial, Helvetica, sans-serif',
+  fontSize: '14px',
+});
+
+export default ModeToggle;

--- a/src/app/components/ThemeSwitcher.tsx
+++ b/src/app/components/ThemeSwitcher.tsx
@@ -9,9 +9,6 @@ const ThemeSwitcher: React.FC = () => {
   return (
     <div
       style={{
-        position: 'fixed',
-        top: '10px',
-        right: '10px',
         padding: '10px',
         background: 'rgba(255,255,255,0.8)',
         border: '1px solid #ccc',

--- a/src/app/contexts/ModeContext.tsx
+++ b/src/app/contexts/ModeContext.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+export type Mode = 'classic' | 'algebraic';
+
+interface ModeContextType {
+  mode: Mode;
+  setMode: (mode: Mode) => void;
+}
+
+const ModeContext = createContext<ModeContextType | undefined>(undefined);
+
+export const ModeProvider = ({ children }: { children: ReactNode }) => {
+  const [mode, setMode] = useState<Mode>('classic');
+  return <ModeContext.Provider value={{ mode, setMode }}>{children}</ModeContext.Provider>;
+};
+
+export const useMode = () => {
+  const context = useContext(ModeContext);
+  if (context === undefined) {
+    throw new Error('useMode must be used within a ModeProvider');
+  }
+  return context;
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "./contexts/ThemeContext";
+import { ModeProvider } from "./contexts/ModeContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,7 +29,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <ThemeProvider>{children}</ThemeProvider>
+        <ThemeProvider>
+          <ModeProvider>{children}</ModeProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useTheme } from './contexts/ThemeContext';
 import ThemeSwitcher from './components/ThemeSwitcher'; // Import ThemeSwitcher
+import { useMode } from './contexts/ModeContext';
+import ModeToggle from './components/ModeToggle';
 import NumberButton from './components/NumberButton';
 import { NumberButtonProvider } from './components/NumberButtonProvider';
 import OperationButton from './components/OperationButton';
@@ -29,8 +31,35 @@ export default function Home() {
   const [operator, setOperator] = useState<Operation | null>(null);
   const [waitingForOperand, setWaitingForOperand] = useState<boolean>(false);
   const { theme } = useTheme();
+  const { mode } = useMode();
+
+  // Clear the display whenever the user switches modes
+  useEffect(() => {
+    handleClearClick();
+  }, [mode]);
 
   const handleSpecialClick = (value: string) => {
+    if (mode === 'algebraic') {
+      switch (value) {
+        case 'AC':
+          handleClearClick();
+          break;
+        case '.':
+          setDisplayValue((prev) => (prev === '0' ? '0.' : prev + '.'));
+          break;
+        case '(':
+        case ')':
+          setDisplayValue((prev) => (prev === '0' ? value : prev + value));
+          break;
+        case '=':
+          // evaluation not implemented yet
+          break;
+        default:
+          // ignore other specials in algebraic mode for now
+          break;
+      }
+      return;
+    }
     switch (value) {
       case 'AC':
         handleClearClick();
@@ -52,7 +81,7 @@ export default function Home() {
     }
   };
 
-  const calculate = (val1: number, op: Operation, val2: number): number => {
+const calculate = (val1: number, op: Operation, val2: number): number => {
     switch (op) {
       case Operation.Add:
         return val1 + val2;
@@ -68,9 +97,20 @@ export default function Home() {
       default:
         return val2; // Should not happen
     }
-  };
+};
+
+const operatorSymbols: Record<Operation, string> = {
+  [Operation.Add]: '+',
+  [Operation.Subtract]: '-',
+  [Operation.Multiply]: '×',
+  [Operation.Divide]: '÷',
+};
 
   const handleNumberClick = (num: string) => {
+    if (mode === 'algebraic') {
+      setDisplayValue(displayValue === '0' ? num : displayValue + num);
+      return;
+    }
     if (waitingForOperand) {
       setDisplayValue(num);
       setWaitingForOperand(false);
@@ -80,6 +120,11 @@ export default function Home() {
   };
 
   const handleOperatorClick = (op: Operation) => {
+    if (mode === 'algebraic') {
+      const symbol = operatorSymbols[op];
+      setDisplayValue(displayValue === '0' ? symbol : displayValue + symbol);
+      return;
+    }
     const currentValue = parseFloat(displayValue);
 
     if (isNaN(currentValue) && displayValue !== "Error") return; // Ignore if current display is not a number unless it's already an error
@@ -110,6 +155,10 @@ export default function Home() {
   };
 
   const handleEqualClick = () => {
+    if (mode === 'algebraic') {
+      // evaluation will be implemented later
+      return;
+    }
     const currentValue = parseFloat(displayValue);
 
     if (isNaN(currentValue) && displayValue !== "Error") return;
@@ -164,8 +213,11 @@ export default function Home() {
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-100">
-      {/* ThemeSwitcher can be placed here, or inside the calculator-container for better positioning relative to it */}
-      <ThemeSwitcher />
+      {/* Theme and mode toggles */}
+      <div className="fixed top-2 right-2 flex flex-col sm:flex-row gap-2 items-end">
+        <ModeToggle />
+        <ThemeSwitcher />
+      </div>
       <div className="calculator-container bg-white p-4 rounded shadow-lg w-80">
         <div className="display bg-gray-200 text-right p-2 rounded mb-4 text-3xl h-20 flex items-center justify-end">
           {displayValue}
@@ -201,6 +253,15 @@ export default function Home() {
           />
                 <SpecialButton value="." />
                 <SpecialButton value="=" className="bg-orange-400 hover:bg-orange-500 active:bg-orange-600 text-white" />
+                {mode === 'algebraic' && (
+                  <>
+                    {/* Row 6 */}
+                    <SpecialButton value="(" />
+                    <SpecialButton value=")" />
+                    <div className="invisible" />
+                    <div className="invisible" />
+                  </>
+                )}
               </div>
             </NumberButtonProvider>
           </OperationButtonProvider>

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,6 +1,6 @@
 export enum Operation {
   Add = '+',
   Subtract = '-',
-  Multiply = 'x',
-  Divide = '➗',
+  Multiply = '×',
+  Divide = '÷',
 }


### PR DESCRIPTION
## Summary
- add `ModeContext` and `ModeToggle`
- wrap app in `ModeProvider`
- show parentheses buttons in algebraic mode
- append tokens to display when in algebraic mode
- use × and ÷ symbols for multiply and divide
- note completed step in TODO
- prevent toggle overlap and clear display on mode change
- document algebraic mode behavior
- remind agents to keep README up to date

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_684c698e6f68832cac1688029468b816