### PR TITLE
Improve arithmetic parser tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ top right of the app to try them. Available themes are:
 
 Use the mode toggle at the top right to switch between **classic** and **algebraic** modes. Algebraic mode shows extra parentheses buttons and lets you type expressions like `1-(2×3)` directly in the display. Evaluation of these algebraic expressions isn't implemented yet, so `=` currently does nothing in this mode.
 
+### Symbolic engine
+
+The groundwork for symbolic calculations has begun. `src/lib/symbolic/parser.ts`
+parses expressions containing `+`, `-`, `×` and `÷` (including decimal numbers)
+into a small AST using a lightweight parser-combinator library. This custom
+grammar will make it easy to add variables and other features in the future.
+

--- a/TODO.md
+++ b/TODO.md
@@ -27,10 +27,6 @@ Keeping the symbolic logic in `src/lib/symbolic` keeps the React UI focused only
    - Text field above the keypad for typing complete expressions.
    - When `=` or `Enter` is pressed in algebraic mode, evaluate the expression.
    - User-visible change: typed expressions like `2*(3+4)` are handled.
-3. **Build the parser** (`parser.ts`)
-   - Tokenise basic operators (+, -, ×, ÷) and parentheses.
-   - Produce an AST structure used throughout the symbolic engine.
-   - Include unit tests to validate parsing.
 4. **Numeric evaluation using the AST** (`evaluate.ts`)
    - Replace the string-based calculation with evaluation of the AST.
    - User-visible change: expression input is interpreted with operator precedence.
@@ -56,3 +52,4 @@ Each stage introduces new functionality visible to the user while keeping the im
 ## Recently completed work
 
 - Added algebraic/classic mode toggle with parentheses keys
+- Implemented custom arithmetic parser with unit tests

--- a/src/lib/symbolic/parser.test.ts
+++ b/src/lib/symbolic/parser.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { parse, Expression } from './parser';
+
+function number(value: number): Expression {
+  return { type: 'number', value };
+}
+
+function binary(op: '+' | '-' | '×' | '÷', left: Expression, right: Expression): Expression {
+  return { type: 'binary', operator: op, left, right };
+}
+
+describe('parse', () => {
+  it('parses simple addition', () => {
+    expect(parse('1+2')).toEqual(binary('+', number(1), number(2)));
+  });
+
+  it('respects operator precedence', () => {
+    // 2 + 3 × 4 -> 2 + (3 × 4)
+    expect(parse('2+3×4')).toEqual(
+      binary('+', number(2), binary('×', number(3), number(4)))
+    );
+  });
+
+  it('handles parentheses', () => {
+    // (2 + 3) × 4
+    expect(parse('(2+3)×4')).toEqual(
+      binary('×', binary('+', number(2), number(3)), number(4))
+    );
+  });
+
+  it('parses decimal numbers', () => {
+    expect(parse('1.5+2.25')).toEqual(binary('+', number(1.5), number(2.25)));
+  });
+
+  it('parses long addition chain', () => {
+    expect(parse('1+2+3+4+5')).toEqual(
+      binary(
+        '+',
+        binary(
+          '+',
+          binary('+', binary('+', number(1), number(2)), number(3)),
+          number(4)
+        ),
+        number(5)
+      )
+    );
+  });
+
+  it('parses mixed long expression', () => {
+    // 1 + (2 × 3) - (4 ÷ 5) + 6
+    const mult = binary('×', number(2), number(3));
+    const div = binary('÷', number(4), number(5));
+    expect(parse('1+2×3-4÷5+6')).toEqual(
+      binary('+', binary('-', binary('+', number(1), mult), div), number(6))
+    );
+  });
+});

--- a/src/lib/symbolic/parser.ts
+++ b/src/lib/symbolic/parser.ts
@@ -1,0 +1,75 @@
+import { Parser, regex, seq, str, token, lazy, many } from './parserlib';
+
+/**
+ * AST node for a numeric literal.
+ */
+export interface NumberLiteral {
+  type: 'number';
+  value: number;
+}
+
+/**
+ * AST node for a binary expression.
+ */
+export interface BinaryExpression {
+  type: 'binary';
+  operator: '+' | '-' | '×' | '÷';
+  left: Expression;
+  right: Expression;
+}
+
+export type Expression = NumberLiteral | BinaryExpression;
+
+// Basic tokens
+const numberTok = token(regex(/\d+(?:\.\d+)?/)).map<NumberLiteral>(v => ({
+  type: 'number',
+  value: Number(v),
+}));
+const plus = token(str('+'));
+const minus = token(str('-'));
+const times = token(str('×'));
+const divide = token(str('÷'));
+const lparen = token(str('('));
+const rparen = token(str(')'));
+
+// Forward declarations for recursive grammar
+const ExpressionP: Parser<Expression> = lazy(() => Sum);
+
+// factor: number | '(' Expression ')'
+const Factor: Parser<Expression> = numberTok.or(
+  seq(lparen, ExpressionP, rparen).map(([, expr]) => expr)
+);
+
+// term: Factor ( (× | ÷) Factor )*
+const Term: Parser<Expression> = seq(Factor, many(seq(times.or(divide), Factor)))
+  .map(([first, rest]) => {
+    return rest.reduce<Expression>((left, [op, right]) => ({
+      type: 'binary',
+      operator: op as '×' | '÷',
+      left,
+      right,
+    }), first);
+  });
+
+// sum: Term ( (+ | -) Term )*
+const Sum: Parser<Expression> = seq(Term, many(seq(plus.or(minus), Term)))
+  .map(([first, rest]) => {
+    return rest.reduce<Expression>((left, [op, right]) => ({
+      type: 'binary',
+      operator: op as '+' | '-',
+      left,
+      right,
+    }), first);
+  });
+
+/**
+ * Parse an arithmetic expression containing +, -, ×, ÷ and parentheses.
+ */
+export function parse(input: string): Expression {
+  const result = ExpressionP.run(input);
+  if (!result.ok || result.index !== input.length) {
+    const idx = result.ok ? result.index : result.index;
+    throw new SyntaxError(`Parse error at index ${idx}`);
+  }
+  return result.value;
+}

--- a/src/lib/symbolic/parserlib.ts
+++ b/src/lib/symbolic/parserlib.ts
@@ -1,0 +1,94 @@
+export type ParseResult<T> =
+  | { ok: true; value: T; index: number }
+  | { ok: false; expected: string; index: number };
+
+export class Parser<T> {
+  constructor(private readonly fn: (input: string, index: number) => ParseResult<T>) {}
+
+  run(input: string, index = 0): ParseResult<T> {
+    return this.fn(input, index);
+  }
+
+  map<U>(f: (v: T) => U): Parser<U> {
+    return new Parser((input, index) => {
+      const res = this.fn(input, index);
+      return res.ok ? { ok: true, value: f(res.value), index: res.index } : res;
+    });
+  }
+
+  chain<U>(f: (v: T) => Parser<U>): Parser<U> {
+    return new Parser((input, index) => {
+      const res = this.fn(input, index);
+      return res.ok ? f(res.value).run(input, res.index) : res;
+    });
+  }
+
+  then<U>(next: Parser<U>): Parser<U> {
+    return this.chain(() => next);
+  }
+
+  or(other: Parser<T>): Parser<T> {
+    return new Parser((input, index) => {
+      const res = this.fn(input, index);
+      return res.ok ? res : other.run(input, index);
+    });
+  }
+}
+
+export function str(s: string): Parser<string> {
+  return new Parser((input, index) =>
+    input.startsWith(s, index)
+      ? { ok: true, value: s, index: index + s.length }
+      : { ok: false, expected: s, index }
+  );
+}
+
+export function regex(r: RegExp): Parser<string> {
+  const anchored = new RegExp('^' + r.source);
+  return new Parser((input, index) => {
+    const match = anchored.exec(input.slice(index));
+    return match
+      ? { ok: true, value: match[0], index: index + match[0].length }
+      : { ok: false, expected: r.source, index };
+  });
+}
+
+export function seq<A, B>(a: Parser<A>, b: Parser<B>): Parser<[A, B]>;
+export function seq<A, B, C>(a: Parser<A>, b: Parser<B>, c: Parser<C>): Parser<[A, B, C]>;
+export function seq(...parsers: Parser<any>[]): Parser<any[]> {
+  return new Parser((input, index) => {
+    const values: any[] = [];
+    let i = index;
+    for (const p of parsers) {
+      const res = p.run(input, i);
+      if (!res.ok) return res;
+      values.push(res.value);
+      i = res.index;
+    }
+    return { ok: true, value: values, index: i };
+  });
+}
+
+export function many<T>(p: Parser<T>): Parser<T[]> {
+  return new Parser((input, index) => {
+    const values: T[] = [];
+    let i = index;
+    while (true) {
+      const res = p.run(input, i);
+      if (!res.ok) break;
+      values.push(res.value);
+      i = res.index;
+    }
+    return { ok: true, value: values, index: i };
+  });
+}
+
+export function lazy<T>(thunk: () => Parser<T>): Parser<T> {
+  return new Parser((input, index) => thunk().run(input, index));
+}
+
+export const whitespace = regex(/[\s]*/);
+
+export function token<T>(p: Parser<T>): Parser<T> {
+  return seq(whitespace, p, whitespace).map(([, v]) => v);
+}


### PR DESCRIPTION
## Summary
- support decimal numbers in arithmetic parser
- document decimal parsing capabilities
- add tests for decimals and longer expressions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c752f624c832cad8653f7328de352