### PR TITLE
Add AST evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ top right of the app to try them. Available themes are:
 
 ### Modes
 
-Use the mode toggle at the top right to switch between **classic** and **algebraic** modes. Algebraic mode shows extra parentheses buttons and lets you type expressions like `1-(2×3)` directly in the display. Evaluation of these algebraic expressions isn't implemented yet, so `=` currently does nothing in this mode.
+Use the mode toggle at the top right to switch between **classic** and **algebraic** modes. Algebraic mode shows extra parentheses buttons and lets you type expressions like `1-(2×3)` directly in the display. These expressions are parsed with normal operator precedence. A numeric evaluator is available, but the UI does not call it yet.
 
 ### Symbolic engine
 
@@ -24,4 +24,5 @@ The groundwork for symbolic calculations has begun. `src/lib/symbolic/parser.ts`
 parses expressions containing `+`, `-`, `×` and `÷` (including decimal numbers)
 into a small AST using a lightweight parser-combinator library. This custom
 grammar will make it easy to add variables and other features in the future.
+`src/lib/symbolic/evaluate.ts` walks that AST to compute a numeric result.
 

--- a/TODO.md
+++ b/TODO.md
@@ -27,9 +27,6 @@ Keeping the symbolic logic in `src/lib/symbolic` keeps the React UI focused only
    - Text field above the keypad for typing complete expressions.
    - When `=` or `Enter` is pressed in algebraic mode, evaluate the expression.
    - User-visible change: typed expressions like `2*(3+4)` are handled.
-4. **Numeric evaluation using the AST** (`evaluate.ts`)
-   - Replace the string-based calculation with evaluation of the AST.
-   - User-visible change: expression input is interpreted with operator precedence.
 5. **Variable support**
    - Extend the parser to recognise single-letter variables.
    - Allow assignments like `x=2` and use stored values in later expressions.
@@ -53,3 +50,4 @@ Each stage introduces new functionality visible to the user while keeping the im
 
 - Added algebraic/classic mode toggle with parentheses keys
 - Implemented custom arithmetic parser with unit tests
+- Added numeric evaluation of the AST with unit tests

--- a/src/lib/symbolic/evaluate.test.ts
+++ b/src/lib/symbolic/evaluate.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from './parser';
+import { evaluate } from './evaluate';
+
+function evalExpr(expr: string): number {
+  return evaluate(parse(expr));
+}
+
+describe('evaluate', () => {
+  it('evaluates simple addition', () => {
+    expect(evalExpr('1+2')).toBe(3);
+  });
+
+  it('respects operator precedence', () => {
+    expect(evalExpr('2+3×4')).toBe(14);
+  });
+
+  it('handles parentheses', () => {
+    expect(evalExpr('(2+3)×4')).toBe(20);
+  });
+
+  it('evaluates decimals', () => {
+    expect(evalExpr('1.5+2.25')).toBeCloseTo(3.75);
+  });
+
+  it('evaluates mixed long expression', () => {
+    expect(evalExpr('1+2×3-4÷5+6')).toBeCloseTo(1 + 2*3 - 4/5 + 6);
+  });
+});

--- a/src/lib/symbolic/evaluate.ts
+++ b/src/lib/symbolic/evaluate.ts
@@ -1,0 +1,27 @@
+import { Expression } from './parser';
+
+export function evaluate(expr: Expression): number {
+  switch (expr.type) {
+    case 'number':
+      return expr.value;
+    case 'binary': {
+      const left = evaluate(expr.left);
+      const right = evaluate(expr.right);
+      switch (expr.operator) {
+        case '+':
+          return left + right;
+        case '-':
+          return left - right;
+        case '×':
+          return left * right;
+        case '÷':
+          return left / right;
+        default:
+          throw new Error(`Unknown operator ${(expr as any).operator}`);
+      }
+    }
+    default:
+      const _exhaustive: never = expr;
+      return _exhaustive;
+  }
+}


### PR DESCRIPTION
## Summary
- implement numeric AST evaluator
- test evaluator and update README
- update roadmap
- fix README: clarify evaluator isn't wired to UI yet

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684c8d15325c832c8b8c18f915a3effc