### PR TITLE
Add typecheck script and fix tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,4 @@
 - Consult `TODO.md` in the repository root to understand the current roadmap and pending tasks.
 - When a task in `TODO.md` is finished, move it to the **Recently completed work** section of that file to keep the list up to date.
 - Keep `README.md` updated with new features so users know how to use them.
+- Always run `npm run lint`, `npm run typecheck`, and `npm test` before submitting a PR.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ top right of the app to try them. Available themes are:
 
 ### Modes
 
-Use the mode toggle at the top right to switch between **classic** and **algebraic** modes. Algebraic mode shows extra parentheses buttons and lets you type expressions like `1-(2×3)` directly in the display. Evaluation of these algebraic expressions isn't implemented yet, so `=` currently does nothing in this mode.
+Use the mode toggle at the top right to switch between **classic** and **algebraic** modes. Algebraic mode shows extra parentheses buttons and lets you type expressions like `1-(2×3)` directly in the display. These expressions are parsed with normal operator precedence. A numeric evaluator is available, but the UI does not call it yet.
 
 ### Symbolic engine
 
@@ -24,4 +24,5 @@ The groundwork for symbolic calculations has begun. `src/lib/symbolic/parser.ts`
 parses expressions containing `+`, `-`, `×` and `÷` (including decimal numbers)
 into a small AST using a lightweight parser-combinator library. This custom
 grammar will make it easy to add variables and other features in the future.
+`src/lib/symbolic/evaluate.ts` walks that AST to compute a numeric result.
 

--- a/TODO.md
+++ b/TODO.md
@@ -27,9 +27,6 @@ Keeping the symbolic logic in `src/lib/symbolic` keeps the React UI focused only
    - Text field above the keypad for typing complete expressions.
    - When `=` or `Enter` is pressed in algebraic mode, evaluate the expression.
    - User-visible change: typed expressions like `2*(3+4)` are handled.
-4. **Numeric evaluation using the AST** (`evaluate.ts`)
-   - Replace the string-based calculation with evaluation of the AST.
-   - User-visible change: expression input is interpreted with operator precedence.
 5. **Variable support**
    - Extend the parser to recognise single-letter variables.
    - Allow assignments like `x=2` and use stored values in later expressions.
@@ -53,3 +50,4 @@ Each stage introduces new functionality visible to the user while keeping the im
 
 - Added algebraic/classic mode toggle with parentheses keys
 - Implemented custom arithmetic parser with unit tests
+- Added numeric evaluation of the AST with unit tests

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 		"preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
 		"versioned-deploy": "opennextjs-cloudflare build && wrangler versions upload",
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts",
-		"test": "vitest"
+                "test": "vitest",
+                "typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@opennextjs/cloudflare": "^1.2.1",

--- a/src/app/components/OperationButton.test.tsx
+++ b/src/app/components/OperationButton.test.tsx
@@ -1,5 +1,7 @@
+/// <reference types="vitest" />
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import OperationButton from './OperationButton';
 import { OperationButtonProvider } from './OperationButtonProvider';
@@ -10,7 +12,7 @@ const MockIcon = () => <svg data-testid="mock-icon"></svg>;
 
 describe('OperationButton', () => {
   it('renders the button with the icon', () => {
-    const mockHandleOperationClick = jest.fn();
+    const mockHandleOperationClick = vi.fn();
     render(
       <OperationButtonProvider onOperationClick={mockHandleOperationClick}>
         <OperationButton operation={Operation.Add} icon={<MockIcon />} />
@@ -21,7 +23,7 @@ describe('OperationButton', () => {
   });
 
   it('calls onOperationClick with the correct operation when clicked', () => {
-    const mockHandleOperationClick = jest.fn();
+    const mockHandleOperationClick = vi.fn();
     render(
       <OperationButtonProvider onOperationClick={mockHandleOperationClick}>
         <OperationButton operation={Operation.Add} icon={<MockIcon />} />
@@ -33,7 +35,7 @@ describe('OperationButton', () => {
   });
 
   it('applies custom className', () => {
-    const mockHandleOperationClick = jest.fn();
+    const mockHandleOperationClick = vi.fn();
     render(
       <OperationButtonProvider onOperationClick={mockHandleOperationClick}>
         <OperationButton operation={Operation.Add} icon={<MockIcon />} className="custom-class" />

--- a/src/app/components/SpecialButton.test.tsx
+++ b/src/app/components/SpecialButton.test.tsx
@@ -1,12 +1,14 @@
+/// <reference types="vitest" />
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import SpecialButton from './SpecialButton';
 import { SpecialButtonProvider } from './SpecialButtonProvider';
 
 describe('SpecialButton', () => {
   it('renders the button with its value as text by default', () => {
-    const mockHandleSpecialClick = jest.fn();
+    const mockHandleSpecialClick = vi.fn();
     render(
       <SpecialButtonProvider onSpecialClick={mockHandleSpecialClick}>
         <SpecialButton value="AC" />
@@ -16,7 +18,7 @@ describe('SpecialButton', () => {
   });
 
   it('renders children if provided', () => {
-    const mockHandleSpecialClick = jest.fn();
+    const mockHandleSpecialClick = vi.fn();
     render(
       <SpecialButtonProvider onSpecialClick={mockHandleSpecialClick}>
         <SpecialButton value="PLUSMINUS"><span>+/-</span></SpecialButton>
@@ -27,7 +29,7 @@ describe('SpecialButton', () => {
   });
 
   it('calls onSpecialClick with the correct value when clicked', () => {
-    const mockHandleSpecialClick = jest.fn();
+    const mockHandleSpecialClick = vi.fn();
     const testValue = "AC";
     render(
       <SpecialButtonProvider onSpecialClick={mockHandleSpecialClick}>
@@ -40,7 +42,7 @@ describe('SpecialButton', () => {
   });
 
   it('applies custom className', () => {
-    const mockHandleSpecialClick = jest.fn();
+    const mockHandleSpecialClick = vi.fn();
     render(
       <SpecialButtonProvider onSpecialClick={mockHandleSpecialClick}>
         <SpecialButton value="AC" className="custom-class" />

--- a/src/lib/symbolic/evaluate.test.ts
+++ b/src/lib/symbolic/evaluate.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from './parser';
+import { evaluate } from './evaluate';
+
+function evalExpr(expr: string): number {
+  return evaluate(parse(expr));
+}
+
+describe('evaluate', () => {
+  it('evaluates simple addition', () => {
+    expect(evalExpr('1+2')).toBe(3);
+  });
+
+  it('respects operator precedence', () => {
+    expect(evalExpr('2+3×4')).toBe(14);
+  });
+
+  it('handles parentheses', () => {
+    expect(evalExpr('(2+3)×4')).toBe(20);
+  });
+
+  it('evaluates decimals', () => {
+    expect(evalExpr('1.5+2.25')).toBeCloseTo(3.75);
+  });
+
+  it('evaluates mixed long expression', () => {
+    expect(evalExpr('1+2×3-4÷5+6')).toBeCloseTo(1 + 2*3 - 4/5 + 6);
+  });
+});

--- a/src/lib/symbolic/evaluate.ts
+++ b/src/lib/symbolic/evaluate.ts
@@ -1,0 +1,27 @@
+import { Expression } from './parser';
+
+export function evaluate(expr: Expression): number {
+  switch (expr.type) {
+    case 'number':
+      return expr.value;
+    case 'binary': {
+      const left = evaluate(expr.left);
+      const right = evaluate(expr.right);
+      switch (expr.operator) {
+        case '+':
+          return left + right;
+        case '-':
+          return left - right;
+        case '×':
+          return left * right;
+        case '÷':
+          return left / right;
+        default:
+          throw new Error('Unknown operator');
+      }
+    }
+    default:
+      const _exhaustive: never = expr;
+      return _exhaustive;
+  }
+}

--- a/src/lib/symbolic/parser.ts
+++ b/src/lib/symbolic/parser.ts
@@ -36,9 +36,9 @@ const rparen = token(str(')'));
 const ExpressionP: Parser<Expression> = lazy(() => Sum);
 
 // factor: number | '(' Expression ')'
-const Factor: Parser<Expression> = numberTok.or(
-  seq(lparen, ExpressionP, rparen).map(([, expr]) => expr)
-);
+const Factor: Parser<Expression> = numberTok
+  .map(expr => expr as Expression)
+  .or(seq(lparen, ExpressionP, rparen).map(([, expr]) => expr));
 
 // term: Factor ( (× | ÷) Factor )*
 const Term: Parser<Expression> = seq(Factor, many(seq(times.or(divide), Factor)))

--- a/src/lib/symbolic/parserlib.ts
+++ b/src/lib/symbolic/parserlib.ts
@@ -55,9 +55,9 @@ export function regex(r: RegExp): Parser<string> {
 
 export function seq<A, B>(a: Parser<A>, b: Parser<B>): Parser<[A, B]>;
 export function seq<A, B, C>(a: Parser<A>, b: Parser<B>, c: Parser<C>): Parser<[A, B, C]>;
-export function seq(...parsers: Parser<any>[]): Parser<any[]> {
+export function seq(...parsers: Parser<unknown>[]): Parser<unknown[]> {
   return new Parser((input, index) => {
-    const values: any[] = [];
+    const values: unknown[] = [];
     let i = index;
     for (const p of parsers) {
       const res = p.run(input, i);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,8 +22,9 @@
       "@/*": ["./src/*"]
     },
     "types": [
-        "./cloudflare-env.d.ts",
-        "node"
+      "./cloudflare-env.d.ts",
+      "node",
+      "vitest"
     ]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- add `typecheck` npm script
- require typecheck in AGENTS instructions
- support Vitest in tsconfig
- fix parser Factor typing
- update tests for Vitest

## Testing
- `npm run lint`
- `npm run typecheck`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_684c8d15325c832c8b8c18f915a3effc