### PR TITLE
Add parse error tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,6 @@ parses expressions containing `+`, `-`, `×` and `÷` (including decimal numbers
 into a small AST using a lightweight parser-combinator library. This custom
 grammar will make it easy to add variables and other features in the future.
 `src/lib/symbolic/evaluate.ts` walks that AST to compute a numeric result.
+Invalid input now raises a `ParseError` that reports the index and expected token,
+making issues easier to diagnose.
 

--- a/src/lib/symbolic/parser.test.ts
+++ b/src/lib/symbolic/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parse, Expression } from './parser';
+import { parse, Expression, ParseError } from './parser';
 
 function number(value: number): Expression {
   return { type: 'number', value };
@@ -53,5 +53,23 @@ describe('parse', () => {
     expect(parse('1+2×3-4÷5+6')).toEqual(
       binary('+', binary('-', binary('+', number(1), mult), div), number(6))
     );
+  });
+
+  describe('errors', () => {
+    it('fails on unexpected operator', () => {
+      expect(() => parse('1++2')).toThrowError(new ParseError(1, 'end of input'));
+    });
+
+    it('fails on unclosed parenthesis', () => {
+      expect(() => parse('(1+2')).toThrowError(new ParseError(4, ')'));
+    });
+
+    it('fails on trailing characters', () => {
+      expect(() => parse('1+2a')).toThrowError(new ParseError(3, 'end of input'));
+    });
+
+    it('fails on empty input', () => {
+      expect(() => parse('')).toThrowError(new ParseError(0, '('));
+    });
   });
 });

--- a/src/lib/symbolic/parser.ts
+++ b/src/lib/symbolic/parser.ts
@@ -1,6 +1,15 @@
 import { Parser, regex, seq, str, token, lazy, many } from './parserlib';
 
 /**
+ * Error thrown when parsing fails.
+ */
+export class ParseError extends SyntaxError {
+  constructor(public index: number, public expected: string) {
+    super(`Expected ${expected} at index ${index}`);
+  }
+}
+
+/**
  * AST node for a numeric literal.
  */
 export interface NumberLiteral {
@@ -67,9 +76,11 @@ const Sum: Parser<Expression> = seq(Term, many(seq(plus.or(minus), Term)))
  */
 export function parse(input: string): Expression {
   const result = ExpressionP.run(input);
-  if (!result.ok || result.index !== input.length) {
-    const idx = result.ok ? result.index : result.index;
-    throw new SyntaxError(`Parse error at index ${idx}`);
+  if (result.ok && result.index === input.length) {
+    return result.value;
   }
-  return result.value;
+
+  const index = result.index;
+  const expected = result.ok ? 'end of input' : result.expected;
+  throw new ParseError(index, expected);
 }


### PR DESCRIPTION
## Summary
- improve parse failure messages via new `ParseError`
- add error handling tests
- document parse errors in README

## Testing
- `npm run lint --fix`
- `npm run typecheck`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d26d436d0832cb2c2e9eabf7fece1