### PR TITLE
Implement variable assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ top right of the app to try them. Available themes are:
 
 Use the mode toggle at the top right to switch between **classic** and **algebraic** modes. Algebraic mode shows extra parentheses buttons and lets you type expressions like `1-(2×3)` directly in the display. Press `=` to evaluate the typed expression; any parse errors will be shown in the display.
 
+Algebraic mode now also supports single-letter variables. Assign values with `x=2` and reference them in later expressions like `x×3`. Assigned variables are listed below the display.
+
 ### Symbolic engine
 
 The groundwork for symbolic calculations has begun. `src/lib/symbolic/parser.ts`

--- a/TODO.md
+++ b/TODO.md
@@ -26,26 +26,22 @@ Keeping the symbolic logic in `src/lib/symbolic` keeps the React UI focused only
 1. **Expression input and evaluation**
    - Add an `ExpressionInput` component above the keypad for typing expressions.
    - Include unit tests verifying that typed expressions like `2*(3+4)` evaluate correctly.
-2. **Variable support**
-   - Extend the parser to recognise single-letter variables.
-   - Allow assignments such as `x=2` and reuse stored values in later expressions.
-   - Provide a simple display of defined variables.
-3. **Simplification routines** (`simplify.ts`)
+2. **Simplification routines** (`simplify.ts`)
    - Implement combining like terms and constant folding.
    - Add a `Simplify` button that shows the simplified form of the current expression.
-4. **Quadratic tools**
+3. **Quadratic tools**
    - Implement factoring of quadratic polynomials in `factor.ts`.
    - Add a routine for completing the square.
    - Surface these features through `Factor` and `Complete Square` buttons.
-5. **General factoring**
+4. **General factoring**
    - Extend `factor.ts` with routines for higher-order polynomials.
    - Provide user feedback when a polynomial cannot be factored over the rationals.
-6. **Equation solving** (`solve.ts`)
+5. **Equation solving** (`solve.ts`)
    - Handle linear and quadratic equations.
    - Provide a `Solve` button that outputs real solutions.
-7. **Enhanced display**
+6. **Enhanced display**
    - Switch algebraic mode to a three-line layout showing the input, the latest transformation, and the result.
-8. **History and step-by-step view**
+7. **History and step-by-step view**
    - Record each transformation so users can review how a result was derived.
    - Allow toggling a full log beneath the calculator.
 
@@ -64,3 +60,4 @@ Each stage introduces new functionality visible to the user while keeping the im
 - Implemented custom arithmetic parser with unit tests
 - Added numeric evaluation of the AST with unit tests
 - Hooked parser and numeric evaluator into algebraic mode; '=' now evaluates typed expressions and displays parse errors
+- Added single-letter variables with assignments and variable display

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,6 +32,7 @@ export default function Home() {
   const [previousValue, setPreviousValue] = useState<number | null>(null);
   const [operator, setOperator] = useState<Operation | null>(null);
   const [waitingForOperand, setWaitingForOperand] = useState<boolean>(false);
+  const [variables, setVariables] = useState<Record<string, number>>({});
   const { theme } = useTheme();
   const { mode } = useMode();
 
@@ -159,7 +160,9 @@ const operatorSymbols: Record<Operation, string> = {
   const handleEqualClick = useCallback(() => {
     if (mode === 'algebraic') {
       try {
-        const result = evaluateExpression(displayValue);
+        const vars = { ...variables };
+        const result = evaluateExpression(displayValue, vars);
+        setVariables(vars);
         setDisplayValue(result.toString());
       } catch (err) {
         if (err instanceof ParseError) {
@@ -190,7 +193,7 @@ const operatorSymbols: Record<Operation, string> = {
       // setWaitingForOperand(true); // Common behavior, can be false if we want to start a new calculation immediately
       setWaitingForOperand(true);
     }
-  }, [mode, displayValue, operator, previousValue]);
+  }, [mode, displayValue, operator, previousValue, variables]);
 
   const handleClearClick = () => {
     setDisplayValue("0");
@@ -243,6 +246,13 @@ const operatorSymbols: Record<Operation, string> = {
         <div className="display bg-gray-200 text-right p-2 rounded mb-4 text-3xl h-20 flex items-center justify-end">
           {displayValue}
         </div>
+        {mode === 'algebraic' && Object.keys(variables).length > 0 && (
+          <div className="text-sm mb-2 text-right">
+            {Object.entries(variables)
+              .map(([k, v]) => `${k}=${v}`)
+              .join(', ')}
+          </div>
+        )}
         <SpecialButtonProvider onSpecialClick={handleSpecialClick}>
           <OperationButtonProvider onOperationClick={handleOperatorClick}>
             <NumberButtonProvider onNumberClick={handleNumberClick}>

--- a/src/lib/symbolic/evaluate.test.ts
+++ b/src/lib/symbolic/evaluate.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { parse } from './parser';
 import { evaluate } from './evaluate';
 
-function evalExpr(expr: string): number {
-  return evaluate(parse(expr));
+function evalExpr(expr: string, env: Record<string, number> = {}): number {
+  return evaluate(parse(expr), env);
 }
 
 describe('evaluate', () => {
@@ -25,5 +25,12 @@ describe('evaluate', () => {
 
   it('evaluates mixed long expression', () => {
     expect(evalExpr('1+2×3-4÷5+6')).toBeCloseTo(1 + 2*3 - 4/5 + 6);
+  });
+
+  it('evaluates assignments and variable references', () => {
+    const env: Record<string, number> = {};
+    expect(evalExpr('x=2', env)).toBe(2);
+    expect(env.x).toBe(2);
+    expect(evalExpr('x+3', env)).toBe(5);
   });
 });

--- a/src/lib/symbolic/evaluate.ts
+++ b/src/lib/symbolic/evaluate.ts
@@ -1,12 +1,15 @@
 import { Expression } from './parser';
 
-export function evaluate(expr: Expression): number {
+export function evaluate(
+  expr: Expression,
+  env: Record<string, number> = {}
+): number {
   switch (expr.type) {
     case 'number':
       return expr.value;
     case 'binary': {
-      const left = evaluate(expr.left);
-      const right = evaluate(expr.right);
+      const left = evaluate(expr.left, env);
+      const right = evaluate(expr.right, env);
       switch (expr.operator) {
         case '+':
           return left + right;
@@ -19,6 +22,15 @@ export function evaluate(expr: Expression): number {
         default:
           throw new Error('Unknown operator');
       }
+    }
+    case 'variable': {
+      if (expr.name in env) return env[expr.name];
+      throw new Error(`Undefined variable ${expr.name}`);
+    }
+    case 'assignment': {
+      const val = evaluate(expr.value, env);
+      env[expr.name] = val;
+      return val;
     }
     default:
       const _exhaustive: never = expr;

--- a/src/lib/symbolic/evaluateExpression.test.ts
+++ b/src/lib/symbolic/evaluateExpression.test.ts
@@ -9,4 +9,11 @@ describe('evaluateExpression', () => {
   it('throws on invalid input', () => {
     expect(() => evaluateExpression('1++2')).toThrow();
   });
+
+  it('supports assignments', () => {
+    const env: Record<string, number> = {};
+    expect(evaluateExpression('x=5', env)).toBe(5);
+    expect(env.x).toBe(5);
+    expect(evaluateExpression('x×2', env)).toBe(10);
+  });
 });

--- a/src/lib/symbolic/evaluateExpression.ts
+++ b/src/lib/symbolic/evaluateExpression.ts
@@ -1,7 +1,10 @@
 import { parse } from './parser';
 import { evaluate } from './evaluate';
 
-export function evaluateExpression(input: string): number {
+export function evaluateExpression(
+  input: string,
+  env: Record<string, number> = {}
+): number {
   const ast = parse(input);
-  return evaluate(ast);
+  return evaluate(ast, env);
 }

--- a/src/lib/symbolic/parser.test.ts
+++ b/src/lib/symbolic/parser.test.ts
@@ -9,6 +9,14 @@ function binary(op: '+' | '-' | '×' | '÷', left: Expression, right: Expression
   return { type: 'binary', operator: op, left, right };
 }
 
+function variable(name: string): Expression {
+  return { type: 'variable', name };
+}
+
+function assignment(name: string, value: Expression): Expression {
+  return { type: 'assignment', name, value };
+}
+
 describe('parse', () => {
   it('parses simple addition', () => {
     expect(parse('1+2')).toEqual(binary('+', number(1), number(2)));
@@ -30,6 +38,14 @@ describe('parse', () => {
 
   it('parses decimal numbers', () => {
     expect(parse('1.5+2.25')).toEqual(binary('+', number(1.5), number(2.25)));
+  });
+
+  it('parses variable references', () => {
+    expect(parse('x')).toEqual(variable('x'));
+  });
+
+  it('parses assignments', () => {
+    expect(parse('x=2')).toEqual(assignment('x', number(2)));
   });
 
   it('parses long addition chain', () => {


### PR DESCRIPTION
## Summary
- extend symbolic parser with variables and assignment expressions
- evaluate variables in a mutable environment
- expose variable assignments in the UI
- document variable support in README
- update roadmap and add tests for variables

## Testing
- `npm run lint --fix`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d804e7d84832cba577cd124df162c