### PR TITLE
Add x button for touch users

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,4 @@
 - Commit messages should use imperative mood (e.g. "Add parser tests").
 - PR descriptions must summarise user-facing changes and include test results.
 - Add unit tests for new functionality and update `TODO.md` and `README.md` when relevant.
+- Ensure the calculator remains fully usable on touch devices without invoking the on-screen keyboard. Provide buttons for common variables like `x`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ top right of the app to try them. Available themes are:
 
 ### Modes
 
-Use the mode toggle at the top right to switch between **classic** and **algebraic** modes. Algebraic mode shows extra parentheses buttons and lets you type expressions like `1-(2×3)` directly in the display. Press `=` to evaluate the typed expression; any parse errors will be shown in the display.
+Use the mode toggle at the top right to switch between **classic** and **algebraic** modes. Algebraic mode shows extra parentheses buttons and a dedicated **x** key so touch devices can enter variables without the on‑screen keyboard. An input field above the keypad still accepts keyboard input for typing expressions like `1-(2×3)` or `x+2`. Press `=` to evaluate the typed expression; any parse errors will be shown in the display.
+
+Algebraic mode now also supports single-letter variables. Assign values with `x=2` and reference them in later expressions like `x×3`. Assigned variables are listed below the display.
 
 ### Symbolic engine
 

--- a/TODO.md
+++ b/TODO.md
@@ -23,33 +23,26 @@ Keeping the symbolic logic in `src/lib/symbolic` keeps the React UI focused only
 
 ## Step-by-step Path
 
-1. **Expression input and evaluation**
-   - Add an `ExpressionInput` component above the keypad for typing expressions.
-   - Include unit tests verifying that typed expressions like `2*(3+4)` evaluate correctly.
-2. **Variable support**
-   - Extend the parser to recognise single-letter variables.
-   - Allow assignments such as `x=2` and reuse stored values in later expressions.
-   - Provide a simple display of defined variables.
-3. **Simplification routines** (`simplify.ts`)
+1. **Simplification routines** (`simplify.ts`)
    - Implement combining like terms and constant folding.
    - Add a `Simplify` button that shows the simplified form of the current expression.
-4. **Quadratic tools**
+2. **Quadratic tools**
    - Implement factoring of quadratic polynomials in `factor.ts`.
    - Add a routine for completing the square.
    - Surface these features through `Factor` and `Complete Square` buttons.
-5. **General factoring**
+3. **General factoring**
    - Extend `factor.ts` with routines for higher-order polynomials.
    - Provide user feedback when a polynomial cannot be factored over the rationals.
-6. **Equation solving** (`solve.ts`)
+4. **Equation solving** (`solve.ts`)
    - Handle linear and quadratic equations.
    - Provide a `Solve` button that outputs real solutions.
-7. **Enhanced display**
+5. **Enhanced display**
    - Switch algebraic mode to a three-line layout showing the input, the latest transformation, and the result.
-8. **History and step-by-step view**
+6. **History and step-by-step view**
    - Record each transformation so users can review how a result was derived.
    - Allow toggling a full log beneath the calculator.
 
-Each stage introduces new functionality visible to the user while keeping the implementation modular. Begin by adding the new expression input to enable typed calculations, then gradually build out the symbolic engine modules.
+Each stage introduces new functionality visible to the user while keeping the implementation modular. With the expression input in place for typed calculations, the next steps gradually build out the symbolic engine modules.
 
 ## Possible future TODOs
 
@@ -64,3 +57,6 @@ Each stage introduces new functionality visible to the user while keeping the im
 - Implemented custom arithmetic parser with unit tests
 - Added numeric evaluation of the AST with unit tests
 - Hooked parser and numeric evaluator into algebraic mode; '=' now evaluates typed expressions and displays parse errors
+- Added single-letter variables with assignments and variable display
+- Added text input for expressions so variables can be typed with the keyboard
+- Added dedicated x button for algebraic mode so touch devices can enter variables

--- a/src/app/components/ExpressionInput.test.tsx
+++ b/src/app/components/ExpressionInput.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import ExpressionInput from './ExpressionInput';
+
+describe('ExpressionInput', () => {
+  it('calls onChange when the value changes', () => {
+    const handleChange = vi.fn();
+    render(
+      <ExpressionInput value="" onChange={handleChange} />
+    );
+    const input = screen.getByTestId('expression-input');
+    fireEvent.change(input, { target: { value: '2+2' } });
+    expect(handleChange).toHaveBeenCalledWith('2+2');
+  });
+
+  it('calls onEnter when Enter key is pressed', () => {
+    const handleEnter = vi.fn();
+    render(
+      <ExpressionInput value="" onChange={() => {}} onEnter={handleEnter} />
+    );
+    const input = screen.getByTestId('expression-input');
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(handleEnter).toHaveBeenCalled();
+  });
+});

--- a/src/app/components/ExpressionInput.tsx
+++ b/src/app/components/ExpressionInput.tsx
@@ -1,0 +1,33 @@
+'use client';
+import React from 'react';
+
+interface ExpressionInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onEnter?: () => void;
+  className?: string;
+}
+
+export default function ExpressionInput({
+  value,
+  onChange,
+  onEnter,
+  className,
+}: ExpressionInputProps) {
+  return (
+    <input
+      data-testid="expression-input"
+      type="text"
+      className={`bg-gray-200 text-right p-2 rounded mb-4 text-3xl h-20 w-full ${
+        className ?? ''
+      }`}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' && onEnter) {
+          onEnter();
+        }
+      }}
+    />
+  );
+}

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import '@testing-library/jest-dom';
+import Home from './page';
+import { ModeProvider } from './contexts/ModeContext';
+import { ThemeProvider } from './contexts/ThemeContext';
+
+function renderWithProviders() {
+  return render(
+    <ThemeProvider>
+      <ModeProvider>
+        <Home />
+      </ModeProvider>
+    </ThemeProvider>
+  );
+}
+
+describe('Home page', () => {
+  it('shows x button in algebraic mode and inputs x', () => {
+    renderWithProviders();
+    fireEvent.click(screen.getByRole('button', { name: 'Algebraic' }));
+    const xButton = screen.getByRole('button', { name: 'x' });
+    fireEvent.click(xButton);
+    expect(screen.getByTestId('expression-input')).toHaveValue('x');
+  });
+});

--- a/src/lib/symbolic/evaluate.test.ts
+++ b/src/lib/symbolic/evaluate.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { parse } from './parser';
 import { evaluate } from './evaluate';
 
-function evalExpr(expr: string): number {
-  return evaluate(parse(expr));
+function evalExpr(expr: string, env: Record<string, number> = {}): number {
+  return evaluate(parse(expr), env);
 }
 
 describe('evaluate', () => {
@@ -25,5 +25,12 @@ describe('evaluate', () => {
 
   it('evaluates mixed long expression', () => {
     expect(evalExpr('1+2×3-4÷5+6')).toBeCloseTo(1 + 2*3 - 4/5 + 6);
+  });
+
+  it('evaluates assignments and variable references', () => {
+    const env: Record<string, number> = {};
+    expect(evalExpr('x=2', env)).toBe(2);
+    expect(env.x).toBe(2);
+    expect(evalExpr('x+3', env)).toBe(5);
   });
 });

--- a/src/lib/symbolic/evaluate.ts
+++ b/src/lib/symbolic/evaluate.ts
@@ -1,12 +1,15 @@
 import { Expression } from './parser';
 
-export function evaluate(expr: Expression): number {
+export function evaluate(
+  expr: Expression,
+  env: Record<string, number> = {}
+): number {
   switch (expr.type) {
     case 'number':
       return expr.value;
     case 'binary': {
-      const left = evaluate(expr.left);
-      const right = evaluate(expr.right);
+      const left = evaluate(expr.left, env);
+      const right = evaluate(expr.right, env);
       switch (expr.operator) {
         case '+':
           return left + right;
@@ -19,6 +22,15 @@ export function evaluate(expr: Expression): number {
         default:
           throw new Error('Unknown operator');
       }
+    }
+    case 'variable': {
+      if (expr.name in env) return env[expr.name];
+      throw new Error(`Undefined variable ${expr.name}`);
+    }
+    case 'assignment': {
+      const val = evaluate(expr.value, env);
+      env[expr.name] = val;
+      return val;
     }
     default:
       const _exhaustive: never = expr;

--- a/src/lib/symbolic/evaluateExpression.test.ts
+++ b/src/lib/symbolic/evaluateExpression.test.ts
@@ -9,4 +9,11 @@ describe('evaluateExpression', () => {
   it('throws on invalid input', () => {
     expect(() => evaluateExpression('1++2')).toThrow();
   });
+
+  it('supports assignments', () => {
+    const env: Record<string, number> = {};
+    expect(evaluateExpression('x=5', env)).toBe(5);
+    expect(env.x).toBe(5);
+    expect(evaluateExpression('x×2', env)).toBe(10);
+  });
 });

--- a/src/lib/symbolic/evaluateExpression.ts
+++ b/src/lib/symbolic/evaluateExpression.ts
@@ -1,7 +1,10 @@
 import { parse } from './parser';
 import { evaluate } from './evaluate';
 
-export function evaluateExpression(input: string): number {
+export function evaluateExpression(
+  input: string,
+  env: Record<string, number> = {}
+): number {
   const ast = parse(input);
-  return evaluate(ast);
+  return evaluate(ast, env);
 }

--- a/src/lib/symbolic/parser.test.ts
+++ b/src/lib/symbolic/parser.test.ts
@@ -9,6 +9,14 @@ function binary(op: '+' | '-' | '×' | '÷', left: Expression, right: Expression
   return { type: 'binary', operator: op, left, right };
 }
 
+function variable(name: string): Expression {
+  return { type: 'variable', name };
+}
+
+function assignment(name: string, value: Expression): Expression {
+  return { type: 'assignment', name, value };
+}
+
 describe('parse', () => {
   it('parses simple addition', () => {
     expect(parse('1+2')).toEqual(binary('+', number(1), number(2)));
@@ -30,6 +38,14 @@ describe('parse', () => {
 
   it('parses decimal numbers', () => {
     expect(parse('1.5+2.25')).toEqual(binary('+', number(1.5), number(2.25)));
+  });
+
+  it('parses variable references', () => {
+    expect(parse('x')).toEqual(variable('x'));
+  });
+
+  it('parses assignments', () => {
+    expect(parse('x=2')).toEqual(assignment('x', number(2)));
   });
 
   it('parses long addition chain', () => {


### PR DESCRIPTION
## Summary
- add x variable button and move parentheses row above AC row
- ensure accessibility for touch devices in AGENTS instructions
- document new x button in README and TODO
- test Home page to ensure x button appends to expression

## Testing
- `npm run lint --fix`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d804e7d84832cba577cd124df162c